### PR TITLE
ppc: fixed incorrect name filed in vmstate_tlbemb_entry

### DIFF
--- a/target/ppc/machine.c
+++ b/target/ppc/machine.c
@@ -602,7 +602,7 @@ static bool tlbemb_needed(void *opaque)
 }
 
 static const VMStateDescription vmstate_tlbemb = {
-    .name = "cpu/tlb6xx",
+    .name = "cpu/tlbemb",
     .version_id = 1,
     .minimum_version_id = 1,
     .needed = tlbemb_needed,


### PR DESCRIPTION
Fix commit: a90db1584a00dc1d1439dc7729d99674b666b85e
When using the Record/replay feature on ppc emulation (qemu-system-ppc binary), an error occurred during loading:
```
Missing section footer for cpu
```
I found a typo that led to this error
